### PR TITLE
A flag to provide a custom path where to save remote manifests

### DIFF
--- a/harness/git_details.go
+++ b/harness/git_details.go
@@ -1,0 +1,25 @@
+package harness
+
+func GetPipelineFilePath(customGitDetailsFilePath string, p Project, pipeline PipelineContent) string {
+	if len(customGitDetailsFilePath) == 0 {
+		return "pipelines/" + string(p.OrgIdentifier) + "/" + p.Identifier + "/" + pipeline.Identifier + ".yaml"
+	} else {
+		return customGitDetailsFilePath + "/" + pipeline.Identifier + ".yaml"
+	}
+}
+
+func GetTemplateFilePath(customGitDetailsFilePath string, p Project, template Template) string {
+	if len(customGitDetailsFilePath) == 0 {
+		return "templates/" + string(p.OrgIdentifier) + "/" + p.Identifier + "/" + template.Identifier + "-" + template.VersionLabel + ".yaml"
+	} else {
+		return customGitDetailsFilePath + "/" + template.Identifier + "-" + template.VersionLabel + ".yaml"
+	}
+}
+
+func GetServiceFilePath(customGitDetailsFilePath string, p Project, service ServiceClass) string {
+	if len(customGitDetailsFilePath) == 0 {
+		return "services/" + string(p.OrgIdentifier) + "/" + p.Identifier + "/" + service.Identifier + ".yaml"
+	} else {
+		return customGitDetailsFilePath + "/" + service.Identifier + ".yaml"
+	}
+}

--- a/main.go
+++ b/main.go
@@ -320,37 +320,13 @@ func main() {
 		}
 	}
 	if scope.Pipelines {
-		log.Infof(boldCyan.Sprintf("---Pipelines---"))
-		if len(failedPipelines) > 0 {
-			log.Warnf(color.HiYellowString("These pipelines (count:%d) failed while moving to remote: \n%s", len(failedPipelines), strings.Join(failedPipelines, ",\n")))
-		}
-		log.Infof(color.GreenString("Processed total of %d pipelines", len(pipelines)))
-		log.Infof(color.GreenString("------"))
-		log.Infof(color.GreenString("Moved pipelines to remote!"))
-		log.Infof(color.GreenString("------"))
+		pipelinesSummary(log, boldCyan, failedPipelines, pipelines)
 	}
 	if scope.Templates {
-		log.Infof(boldCyan.Sprintf("---Templates---"))
-		if len(failedTemplates) > 0 {
-			log.Warnf(color.HiYellowString("These templates (count:%d) failed while moving to remote: \n%s", len(failedTemplates), strings.Join(failedTemplates, ",\n")))
-		}
-		log.Infof(color.GreenString("Processed total of %d templates", len(templates)))
-		log.Infof(color.GreenString("------"))
-		log.Infof(color.GreenString("Moved templates to remote!"))
-		log.Infof(color.GreenString("------"))
+		templatesSummary(log, boldCyan, failedTemplates, templates)
 	}
 	if scope.Services {
-		log.Infof(boldCyan.Sprintf("---Services---"))
-		if len(failedTemplates) > 0 {
-			log.Warnf(color.HiYellowString("These services (count:%d) failed while moving to remote: \n%s", len(failedServices), strings.Join(failedServices, ",\n")))
-		}
-		if len(alreadyRemoteServices) > 0 {
-			log.Warnf(color.HiYellowString("These services (count:%d) already remote: \n%s", len(alreadyRemoteServices), strings.Join(alreadyRemoteServices, ",\n")))
-		}
-		log.Infof(color.GreenString("Processed total of %d services", len(services)))
-		log.Infof(color.GreenString("------"))
-		log.Infof(color.GreenString("Moved services to remote!"))
-		log.Infof(color.GreenString("------"))
+		servicesSummary(log, boldCyan, failedTemplates, failedServices, alreadyRemoteServices, services)
 	}
 	if scope.FileStore {
 		var failedFiles, failedOrgFiles, failedProjectFiles, failedServices []string
@@ -846,4 +822,40 @@ func main() {
 			overridesBar.Finish()
 		}
 	}
+}
+
+func servicesSummary(log *logrus.Logger, boldCyan *color.Color, failedTemplates []string, failedServices []string, alreadyRemoteServices []string, services []*harness.ServiceClass) {
+	log.Infof(boldCyan.Sprintf("---Services---"))
+	if len(failedTemplates) > 0 {
+		log.Warnf(color.HiYellowString("These services (count:%d) failed while moving to remote: \n%s", len(failedServices), strings.Join(failedServices, ",\n")))
+	}
+	if len(alreadyRemoteServices) > 0 {
+		log.Warnf(color.HiYellowString("These services (count:%d) already remote: \n%s", len(alreadyRemoteServices), strings.Join(alreadyRemoteServices, ",\n")))
+	}
+	log.Infof(color.GreenString("Processed total of %d services", len(services)))
+	log.Infof(color.GreenString("------"))
+	log.Infof(color.GreenString("Moved services to remote!"))
+	log.Infof(color.GreenString("------"))
+}
+
+func templatesSummary(log *logrus.Logger, boldCyan *color.Color, failedTemplates []string, templates []harness.Template) {
+	log.Infof(boldCyan.Sprintf("---Templates---"))
+	if len(failedTemplates) > 0 {
+		log.Warnf(color.HiYellowString("These templates (count:%d) failed while moving to remote: \n%s", len(failedTemplates), strings.Join(failedTemplates, ",\n")))
+	}
+	log.Infof(color.GreenString("Processed total of %d templates", len(templates)))
+	log.Infof(color.GreenString("------"))
+	log.Infof(color.GreenString("Moved templates to remote!"))
+	log.Infof(color.GreenString("------"))
+}
+
+func pipelinesSummary(log *logrus.Logger, boldCyan *color.Color, failedPipelines []string, pipelines []harness.PipelineContent) {
+	log.Infof(boldCyan.Sprintf("---Pipelines---"))
+	if len(failedPipelines) > 0 {
+		log.Warnf(color.HiYellowString("These pipelines (count:%d) failed while moving to remote: \n%s", len(failedPipelines), strings.Join(failedPipelines, ",\n")))
+	}
+	log.Infof(color.GreenString("Processed total of %d pipelines", len(pipelines)))
+	log.Infof(color.GreenString("------"))
+	log.Infof(color.GreenString("Moved pipelines to remote!"))
+	log.Infof(color.GreenString("------"))
 }

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ func main() {
 	urlEncoding := flag.Bool("url-encode-string", false, "Encode Paths as URL friendly strings")
 	cgFolderStructure := flag.Bool("alt-path", false, "CG-like folder structure for Git")
 	prod3 := flag.Bool("prod3", false, "User Prod3 base URL for API calls")
+	customGitDetailsFilePath := flag.String("custom-remote-path", "", "A custom file path where to save remote manifests.")
 
 	flag.Parse()
 
@@ -222,7 +223,7 @@ func main() {
 						if scope.CGFolderStructure {
 							accountConfig.GitDetails.FilePath = "account/" + string(p.OrgIdentifier) + "/" + p.Identifier + "/pipelines/" + pipeline.Identifier + ".yaml"
 						} else {
-							accountConfig.GitDetails.FilePath = "pipelines/" + string(p.OrgIdentifier) + "/" + p.Identifier + "/" + pipeline.Identifier + ".yaml"
+							accountConfig.GitDetails.FilePath = harness.GetPipelineFilePath(*customGitDetailsFilePath, p, pipeline)
 						}
 					}
 					_, err := pipeline.MovePipelineToRemote(&api, accountConfig, string(p.OrgIdentifier), p.Identifier)
@@ -260,7 +261,7 @@ func main() {
 							accountConfig.GitDetails.FilePath = "account/" + string(p.OrgIdentifier) + "/" + p.Identifier + "/templates/" + template.Identifier + "-" + template.VersionLabel + ".yaml"
 							template.GitDetails = accountConfig.GitDetails
 						} else {
-							accountConfig.GitDetails.FilePath = "templates/" + string(p.OrgIdentifier) + "/" + p.Identifier + "/" + template.Identifier + "-" + template.VersionLabel + ".yaml"
+							accountConfig.GitDetails.FilePath = harness.GetTemplateFilePath(*customGitDetailsFilePath, p, template)
 							template.GitDetails = accountConfig.GitDetails
 						}
 					}
@@ -296,7 +297,7 @@ func main() {
 				servicesBar := pb.ProgressBarTemplate(servicesTmpl).Start(len(projectServices))
 
 				for _, service := range projectServices {
-					accountConfig.GitDetails.FilePath = "services/" + string(p.OrgIdentifier) + "/" + p.Identifier + "/" + service.Identifier + ".yaml"
+					accountConfig.GitDetails.FilePath = harness.GetServiceFilePath(*customGitDetailsFilePath, p, *service)
 
 					if service.StoreType == "REMOTE" {
 						log.Infof("Service [%s] is already remote", service.Identifier)


### PR DESCRIPTION
Useful when the customer wants one repository per project and looks for folder structure simplification.